### PR TITLE
Remove unnecessary teardown procedure

### DIFF
--- a/polls/tests.py
+++ b/polls/tests.py
@@ -149,11 +149,6 @@ class VoteTests(TestCase):
         )
         self.choice2.save()
 
-    def tearDown(self):
-        self.choice2.delete()
-        self.choice1.delete()
-        self.question.delete()
-
     def test_vote_counts(self):
         url = reverse('polls:vote', args=(self.question.id,))
         # follow=True follows the redirect chain so response is the end page


### PR DESCRIPTION
Unless something funky is going on idk about, Django's `TestCase` is by default wrapping a transaction around each test and rolling it back after, so there's no need to delete objects from the database.

Also FYI this method was asymmetric with setUp, which was calling super, in that it wasn't calling super.